### PR TITLE
[PL-57053]: Publish helm-init-container with version tag

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,0 +1,22 @@
+apiVersion: v2
+name: helm-init-container
+description: A Helm chart for Kubernetes
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 1.0.0
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+# TODO What is this app version?
+appVersion: "0.0.1"

--- a/config/manifest.yaml
+++ b/config/manifest.yaml
@@ -1,2 +1,2 @@
 DOCKER_FILE_PATH: helm-init-container/Dockerfile
-HELM_CHART_SOURCE_DIRECTORY: <none>
+HELM_CHART_SOURCE_DIRECTORY: helm-init-container/chart


### PR DESCRIPTION
Added a dummy helm chart so that we can use the build and release pipeline to build helm-init-container with a version tag instead of latest.