### PR TITLE
fix: [PL-62760]: Change to ubi9-minimal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN echo -e '#!/bin/sh\nexec /usr/bin/microdnf -y "$@"' > /usr/local/bin/microdn
   && chmod +x /usr/local/bin/microdnf
 
 RUN microdnf update --nodocs --setopt=install_weak_deps=0 \
-  && microdnf install -y curl findutils \
+  && microdnf install -y findutils \
   && microdnf clean all
   
 RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && chmod +x ./kubectl && mv ./kubectl /usr/local/bin/kubectl

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM redhat/ubi8-minimal:8.10
+FROM redhat/ubi9-minimal:9.4
 
 RUN microdnf update --nodocs --setopt=install_weak_deps=0 \
   && microdnf install -y curl findutils \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM redhat/ubi9-minimal:9.4
 
+RUN echo -e '#!/bin/sh\nexec /usr/bin/microdnf -y "$@"' > /usr/local/bin/microdnf \
+  && chmod +x /usr/local/bin/microdnf
+
 RUN microdnf update --nodocs --setopt=install_weak_deps=0 \
   && microdnf install -y curl findutils \
   && microdnf clean all


### PR DESCRIPTION
Change base image to redhat/ubi9-minimal:9.4 to remove vuln CVE-2020-11023